### PR TITLE
Clarify schema filter error message

### DIFF
--- a/src/main/java/com/homihq/db2rest/jdbc/rest/schema/SchemaController.java
+++ b/src/main/java/com/homihq/db2rest/jdbc/rest/schema/SchemaController.java
@@ -56,7 +56,7 @@ public class SchemaController implements SchemaRestApi{
 
         String [] fragments = filter.split("==");
 
-        if(fragments.length != 2) throw new GenericDataAccessException("Invalid filter condition. Only == supported for schema filter with a single condition only.");
+        if(fragments.length != 2) throw new GenericDataAccessException("Invalid filter condition. Only == supported for schema filter using a single value only.");
 
         return new SchemaFilter(fragments[0], fragments[1]);
 


### PR DESCRIPTION
- I felt that the term "condition" is too closely related to that of an "expression", etc. and can be confusing for non-English speakers (when translated).  Where the code we have actually only uses a value, so we should just say it that way.