### PR TITLE
Add comment about default service port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,11 @@ WORKDIR /opt/app
 # cp target/db2rest.jar /opt/app/db2rest.jar
 COPY ${JAR_FILE} db2rest.jar
 
+# uncomment EXPOSE if you wish to automatically expose
+# port 8080 (default service port) upon container start
+# otherwise you can map the port on docker run with `-p 1234:8080`
+
+# EXPOSE 8080
+
 # java -jar /opt/app/db2rest.jar
 ENTRYPOINT ["java","-jar","db2rest.jar"]


### PR DESCRIPTION
- Adds comment into `./Dockerfile` just in case someone pulls the image and stuck wondering what the hell is the default service port.  (LIKE I DID!!!)