### PR TITLE
DateTime integration test for all the databases except oracle

### DIFF
--- a/api-rest/src/test/java/com/homihq/db2rest/rest/DateTimeUtil.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/rest/DateTimeUtil.java
@@ -4,6 +4,7 @@ import com.jayway.jsonpath.JsonPath;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.io.UnsupportedEncodingException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -11,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 
 public class DateTimeUtil {
 
-    // Convert LocalDateTime to UTC string
+    // Convert UTC time to LocalDateTime string
     public static String utcToLocalTimestampString(MvcResult result) throws UnsupportedEncodingException {
         String lastUpdateStr = result.getResponse().getContentAsString();
 
@@ -26,4 +27,13 @@ public class DateTimeUtil {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
         return formatter.format(localDateTime);
     }
+
+    // Convert UTC time to Oracle TIMESTAMP Format
+    public static String toOracleTimestampFormat(String dateTimeString) throws UnsupportedEncodingException {
+        // Format the current date and time to a string that Oracle TIMESTAMP understands
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+        LocalDateTime localDateTime = LocalDateTime.parse(dateTimeString, formatter);
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
 }

--- a/api-rest/src/test/java/com/homihq/db2rest/rest/mongo/MongoDBControllerTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/rest/mongo/MongoDBControllerTest.java
@@ -36,6 +36,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static com.homihq.db2rest.mongo.rest.api.MongoRestApi.VERSION;
@@ -326,6 +327,7 @@ class MongoDBControllerTest extends MongoBaseIntegrationTest {
                         .accept(MediaType.APPLICATION_JSON)
                         .param("fields", "FirstName,LastName")
                         .param("filter", "FirstName==PENELOPE"))
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*", hasSize(3)))
                 .andExpect(jsonPath("$.FirstName", equalTo("PENELOPE")))

--- a/api-rest/src/test/java/com/homihq/db2rest/rest/mongo/MongoDBDateTimeAllTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/rest/mongo/MongoDBDateTimeAllTest.java
@@ -1,0 +1,142 @@
+package com.homihq.db2rest.rest.mongo;
+
+import com.adelean.inject.resources.junit.jupiter.WithJacksonMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.homihq.db2rest.MongoBaseIntegrationTest;
+import com.homihq.db2rest.rest.DateTimeUtil;
+import org.bson.Document;
+import org.junit.jupiter.api.*;
+import org.springdoc.api.ErrorMessage;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.homihq.db2rest.mongo.rest.api.MongoRestApi.VERSION;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@Order(492)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class MongoDBDateTimeAllTest extends MongoBaseIntegrationTest {
+
+    @WithJacksonMapper
+    ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    private final String dateTime = "2024-03-15T10:30:45Z";
+
+    @Test
+    @Order(1)
+    @DisplayName("Test Create an actor with datetime fields in MongoDB")
+    void createActorWithDateTimeFields() throws Exception {
+        // Prepare the request with datetime fields
+        Document actorRequestWithDateTime = new Document();
+        actorRequestWithDateTime.put("first_name", "Collective");
+        actorRequestWithDateTime.put("last_name", "Unconscious");
+        actorRequestWithDateTime.put("last_update", LocalDateTime.of(2020,03,15,
+                14,30,45));
+
+        mockMvc.perform(post(VERSION + "/mongo/Sakila_actors")
+                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(actorRequestWithDateTime)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.row", equalTo(1)))
+                .andExpect(jsonPath("$.keys.timestamp").isNumber())
+                .andExpect(jsonPath("$.keys.date").isString())
+                .andDo(document("mongodb-create-an-actor-with-datetime"));
+    }
+
+//    @Test
+//    @Order(1)
+//    @DisplayName("Test Create an actor with error timestamp field in MongoDB")
+//    void createActorWithErrorDateTimeField() throws Exception {
+//        Document actorRequestWithErrorDateTime = new Document()
+//                .append("first_name", "Hero")
+//                .append("last_name", "shadow")
+//                .append("last_update", "2019-15-35T14:75:90"); // Invalid date string
+//
+//        mockMvc.perform(post(VERSION + "/mongo/Sakila_actors")
+//                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+//                        .content(objectMapper.writeValueAsString(actorRequestWithErrorDateTime)))
+//                .andExpect(status().isBadRequest())
+//                .andDo(document("mongodb-create-an-actor-with-error-timestamp"));
+//    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Test update an actor with datetime field in MongoDB")
+    void updateActorWithDateTimeField() throws Exception {
+        // Prepare the request with datetime fields
+        Document updateActorRequestWithDateTime = new Document();
+
+        // Convert the string to a proper OffsetDateTime object
+        OffsetDateTime lastUpdateDateTime = OffsetDateTime.parse("2024-03-15T10:30:45.000+00:00");
+        updateActorRequestWithDateTime.put("last_update", lastUpdateDateTime.toString());
+
+        mockMvc.perform(patch(VERSION + "/mongo/Sakila_actors")
+                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                        .param("filter", "last_name == Unconscious")
+                        .content(objectMapper.writeValueAsString(updateActorRequestWithDateTime)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rows", equalTo(1)))
+                .andDo(document("mongodb-update-an-actor-with-datetime"));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Test get an actor with datetime fields in MongoDB")
+    void getActorWithDateTimeFields() throws Exception {
+        mockMvc.perform(get(VERSION + "/mongo/Sakila_actors/one")
+                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                        .param("filter", "first_name == Collective"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*").isArray())
+                .andExpect(jsonPath("$.last_name", equalTo("Unconscious")))
+                .andExpect(jsonPath("$.last_update", equalTo(dateTime)))
+                .andDo(document("mongodb-get-an-actor-with-datetime"));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Test get an actor filter by timestamp in MongoDB")
+    void getActorFilterByTimeStamp() throws Exception {
+        mockMvc.perform(get(VERSION + "/mongo/Sakila_actors/one")
+                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                        .param("filter", "last_update > \"2023-03-15T10:30:45.00Z\""))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*").isArray())
+                .andExpect(jsonPath("$.last_name", equalTo("Unconscious")))
+                .andExpect(jsonPath("$.last_update", equalTo(dateTime)))
+                .andDo(document("mongodb-get-an-actor-filter-by-timestamp"));
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Test delete an actor by timestamp in MongoDB")
+    void deleteActorByTimeStamp() throws Exception {
+        mockMvc.perform(delete(VERSION + "/mongo/Sakila_actors")
+                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                        .param("filter", "last_update > \"2023-03-15T05:30:45.00Z\""))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*").isArray())
+                .andExpect(jsonPath("$.rows", equalTo(1)))
+                .andDo(document("mongodb-delete-an-actor-by-timestamp"));
+    }
+}

--- a/api-rest/src/test/java/com/homihq/db2rest/rest/mysql/MySQLDateTimeAllTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/rest/mysql/MySQLDateTimeAllTest.java
@@ -1,9 +1,9 @@
-package com.homihq.db2rest.rest.mariadb;
+package com.homihq.db2rest.rest.mysql;
 
 import com.adelean.inject.resources.junit.jupiter.WithJacksonMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.homihq.db2rest.MariaDBBaseIntegrationTest;
+import com.homihq.db2rest.MySQLBaseIntegrationTest;
 import com.homihq.db2rest.rest.DateTimeUtil;
 import org.junit.jupiter.api.*;
 
@@ -20,9 +20,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
-@Order(392)
+@Order(92)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
+public class MySQLDateTimeAllTest extends MySQLBaseIntegrationTest {
 
     @WithJacksonMapper
     ObjectMapper objectMapper = new ObjectMapper()
@@ -40,12 +40,12 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
         actorRequestWithDateTime.put("last_name", "Unconscious");
         actorRequestWithDateTime.put("last_update", "2020-03-15T14:30:45.000");
 
-        mockMvc.perform(post(VERSION + "/mariadb/actor")
+        mockMvc.perform(post(VERSION + "/mysqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(actorRequestWithDateTime)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.row", equalTo(1)))
-                .andDo(document("mariadb-create-an-actor-with-datetime"));
+                .andDo(document("mysql-create-an-actor-with-datetime"));
     }
 
     @Test
@@ -57,11 +57,11 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
         actorRequestWithErrorDateTime.put("last_name", "shadow");
         actorRequestWithErrorDateTime.put("last_update", "2023-15-35T14:75:90");
 
-        mockMvc.perform(post(VERSION + "/mariadb/actor")
+        mockMvc.perform(post(VERSION + "/mysqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(actorRequestWithErrorDateTime)))
                 .andExpect(status().isBadRequest())
-                .andDo(document("mariadb-create-an-actor-with-error-timestamp"));
+                .andDo(document("mysql-create-an-actor-with-error-timestamp"));
     }
 
     @Test
@@ -72,33 +72,33 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
         Map<String, Object> updateActorRequestWithDateTime = new HashMap<>();
         updateActorRequestWithDateTime.put("last_update", dateTime);
 
-        mockMvc.perform(patch(VERSION + "/mariadb/actor")
+        mockMvc.perform(patch(VERSION + "/mysqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "last_name == Unconscious")
                         .content(objectMapper.writeValueAsString(updateActorRequestWithDateTime)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.rows", equalTo(1)))
-                .andDo(document("mariadb-update-an-actor-with-datetime"));
+                .andDo(document("mysql-update-an-actor-with-datetime"));
     }
 
     @Test
     @Order(3)
     @DisplayName("Test get an actor with datetime fields")
     void getActorWithDateTimeFields() throws Exception {
-        mockMvc.perform(get(VERSION + "/mariadb/actor")
+        mockMvc.perform(get(VERSION + "/mysqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "first_name == Collective"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*").isArray())
                 .andDo(result -> assertEquals(dateTime, DateTimeUtil.utcToLocalTimestampString(result)))
-                .andDo(document("mariadb-get-an-actor-with-datetime"));
+                .andDo(document("mysql-get-an-actor-with-datetime"));
     }
 
     @Test
     @Order(3)
     @DisplayName("Test get an actor filter by timestamp")
     void getActorFilterByTimeStamp() throws Exception {
-        mockMvc.perform(get(VERSION + "/mariadb/actor")
+        mockMvc.perform(get(VERSION + "/mysqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "last_update > \"2023-03-15T10:30:45.00Z\""))
 //                .andDo(print())
@@ -106,20 +106,20 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
                 .andExpect(jsonPath("$.*").isArray())
                 .andExpect(jsonPath("[0].last_name", equalTo("Unconscious")))
                 .andDo(result -> assertEquals(dateTime, DateTimeUtil.utcToLocalTimestampString(result)))
-                .andDo(document("mariadb-get-an-actor-filter-by-timestamp"));
+                .andDo(document("mysql-get-an-actor-filter-by-timestamp"));
     }
 
     @Test
     @Order(4)
     @DisplayName("Test delete an actor by timestamp")
     void deleteActorByTimeStamp() throws Exception {
-        mockMvc.perform(delete(VERSION + "/mariadb/actor")
+        mockMvc.perform(delete(VERSION + "/mysqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "last_update > \"2023-03-15T05:30:45.00Z\""))
 //                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*").isArray())
                 .andExpect(jsonPath("$.rows", equalTo(1)))
-                .andDo(document("mariadb-delete-an-actor-by-timestamp"));
+                .andDo(document("mysql-delete-an-actor-by-timestamp"));
     }
 }

--- a/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PGDateTimeAllTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PGDateTimeAllTest.java
@@ -1,9 +1,10 @@
-package com.homihq.db2rest.rest.mariadb;
+package com.homihq.db2rest.rest.pg;
 
 import com.adelean.inject.resources.junit.jupiter.WithJacksonMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.homihq.db2rest.MariaDBBaseIntegrationTest;
+import com.homihq.db2rest.PostgreSQLBaseIntegrationTest;
 import com.homihq.db2rest.rest.DateTimeUtil;
 import org.junit.jupiter.api.*;
 
@@ -20,9 +21,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
-@Order(392)
+@Order(192)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
+public class PGDateTimeAllTest extends PostgreSQLBaseIntegrationTest {
 
     @WithJacksonMapper
     ObjectMapper objectMapper = new ObjectMapper()
@@ -40,12 +41,12 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
         actorRequestWithDateTime.put("last_name", "Unconscious");
         actorRequestWithDateTime.put("last_update", "2020-03-15T14:30:45.000");
 
-        mockMvc.perform(post(VERSION + "/mariadb/actor")
+        mockMvc.perform(post(VERSION + "/pgsqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(actorRequestWithDateTime)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.row", equalTo(1)))
-                .andDo(document("mariadb-create-an-actor-with-datetime"));
+                .andDo(document("pg-create-an-actor-with-datetime"));
     }
 
     @Test
@@ -57,11 +58,11 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
         actorRequestWithErrorDateTime.put("last_name", "shadow");
         actorRequestWithErrorDateTime.put("last_update", "2023-15-35T14:75:90");
 
-        mockMvc.perform(post(VERSION + "/mariadb/actor")
+        mockMvc.perform(post(VERSION + "/pgsqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(actorRequestWithErrorDateTime)))
                 .andExpect(status().isBadRequest())
-                .andDo(document("mariadb-create-an-actor-with-error-timestamp"));
+                .andDo(document("pg-create-an-actor-with-error-timestamp"));
     }
 
     @Test
@@ -72,33 +73,33 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
         Map<String, Object> updateActorRequestWithDateTime = new HashMap<>();
         updateActorRequestWithDateTime.put("last_update", dateTime);
 
-        mockMvc.perform(patch(VERSION + "/mariadb/actor")
+        mockMvc.perform(patch(VERSION + "/pgsqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "last_name == Unconscious")
                         .content(objectMapper.writeValueAsString(updateActorRequestWithDateTime)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.rows", equalTo(1)))
-                .andDo(document("mariadb-update-an-actor-with-datetime"));
+                .andDo(document("pg-update-an-actor-with-datetime"));
     }
 
     @Test
     @Order(3)
     @DisplayName("Test get an actor with datetime fields")
     void getActorWithDateTimeFields() throws Exception {
-        mockMvc.perform(get(VERSION + "/mariadb/actor")
+        mockMvc.perform(get(VERSION + "/pgsqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "first_name == Collective"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*").isArray())
                 .andDo(result -> assertEquals(dateTime, DateTimeUtil.utcToLocalTimestampString(result)))
-                .andDo(document("mariadb-get-an-actor-with-datetime"));
+                .andDo(document("pg-get-an-actor-with-datetime"));
     }
 
     @Test
     @Order(3)
     @DisplayName("Test get an actor filter by timestamp")
     void getActorFilterByTimeStamp() throws Exception {
-        mockMvc.perform(get(VERSION + "/mariadb/actor")
+        mockMvc.perform(get(VERSION + "/pgsqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "last_update > \"2023-03-15T10:30:45.00Z\""))
 //                .andDo(print())
@@ -106,20 +107,20 @@ public class MariadbDateTimeAllTest extends MariaDBBaseIntegrationTest {
                 .andExpect(jsonPath("$.*").isArray())
                 .andExpect(jsonPath("[0].last_name", equalTo("Unconscious")))
                 .andDo(result -> assertEquals(dateTime, DateTimeUtil.utcToLocalTimestampString(result)))
-                .andDo(document("mariadb-get-an-actor-filter-by-timestamp"));
+                .andDo(document("pg-get-an-actor-filter-by-timestamp"));
     }
 
     @Test
     @Order(4)
     @DisplayName("Test delete an actor by timestamp")
     void deleteActorByTimeStamp() throws Exception {
-        mockMvc.perform(delete(VERSION + "/mariadb/actor")
+        mockMvc.perform(delete(VERSION + "/pgsqldb/actor")
                         .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
                         .param("filter", "last_update > \"2023-03-15T05:30:45.00Z\""))
 //                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*").isArray())
                 .andExpect(jsonPath("$.rows", equalTo(1)))
-                .andDo(document("mariadb-delete-an-actor-by-timestamp"));
+                .andDo(document("pg-delete-an-actor-by-timestamp"));
     }
 }

--- a/api-rest/src/test/resources/oracle/oracle-sakila.sql
+++ b/api-rest/src/test/resources/oracle/oracle-sakila.sql
@@ -2,19 +2,20 @@
 -- Table structure for table `tops`
 --
 
+
 CREATE TABLE tops (
-          top_item varchar(30) NOT NULL,
-          color varchar(30) NOT NULL,
-          t_size varchar(2) NOT NULL
+                      top_item varchar(30) NOT NULL,
+                      color varchar(30) NOT NULL,
+                      t_size varchar(2) NOT NULL
 );
 --
 -- Table structure for table `bottoms`
 --
 
 CREATE TABLE bottoms (
-     bottom_item varchar(30) NOT NULL,
-     color varchar(30) NOT NULL,
-     b_size varchar(2) NOT NULL
+                         bottom_item varchar(30) NOT NULL,
+                         color varchar(30) NOT NULL,
+                         b_size varchar(2) NOT NULL
 );
 
 
@@ -26,23 +27,23 @@ CREATE TABLE bottoms (
 --DROP TABLE users;
 
 CREATE TABLE users (
-       auid INT NOT NULL ,
-       username VARCHAR(45) NOT NULL,
-       password VARCHAR(45) NOT NULL,
-       createdate DATE  DEFAULT sysdate,
-       is_active char(1) DEFAULT 'Y',
-       CONSTRAINT pk_users PRIMARY KEY  (auid)
+                       auid INT NOT NULL ,
+                       username VARCHAR(45) NOT NULL,
+                       password VARCHAR(45) NOT NULL,
+                       createdate DATE  DEFAULT sysdate,
+                       is_active char(1) DEFAULT 'Y',
+                       CONSTRAINT pk_users PRIMARY KEY  (auid)
 );
 
 
 CREATE TABLE userprofile (
-     apid INT NOT NULL,
-     auid INT NOT NULL,
-     firstname VARCHAR(50) NOT NULL,
-     lastname VARCHAR(50) NOT NULL,
-     email VARCHAR(100) NOT NULL,
-     phone VARCHAR(45) NOT NULL,
-     CONSTRAINT pk_userprofile PRIMARY KEY  (apid)
+                             apid INT NOT NULL,
+                             auid INT NOT NULL,
+                             firstname VARCHAR(50) NOT NULL,
+                             lastname VARCHAR(50) NOT NULL,
+                             email VARCHAR(100) NOT NULL,
+                             phone VARCHAR(45) NOT NULL,
+                             CONSTRAINT pk_userprofile PRIMARY KEY  (apid)
 );
 
 --
@@ -51,24 +52,25 @@ CREATE TABLE userprofile (
 --DROP TABLE actor;
 
 CREATE TABLE actor (
-       actor_id INT NOT NULL ,
-       first_name VARCHAR(45) NOT NULL,
-       last_name VARCHAR(45) NOT NULL,
-       last_update DATE NOT NULL,
-       CONSTRAINT pk_actor PRIMARY KEY  (actor_id)
+                       actor_id INT NOT NULL ,
+                       first_name VARCHAR(45) NOT NULL,
+                       last_name VARCHAR(45) NOT NULL,
+                       last_update TIMESTAMP NOT NULL,
+                       CONSTRAINT pk_actor PRIMARY KEY  (actor_id)
 );
 
 CREATE  INDEX idx_actor_last_name ON actor(last_name);
 
- 
-  --DROP SEQUENCE actor_sequence;
 
-CREATE SEQUENCE actor_sequence;
+--DROP SEQUENCE actor_sequence;
 
+CREATE SEQUENCE actor_sequence
+    INCREMENT BY 1
+    START WITH 200;
 
 /*
 
-CREATE OR REPLACE TRIGGER actor_before_trigger 
+CREATE OR REPLACE TRIGGER actor_before_trigger
 BEFORE INSERT ON actor FOR EACH ROW
 BEGIN
   IF (:NEW.actor_id IS NULL) THEN
@@ -116,9 +118,9 @@ END;
 */
 
 CREATE OR REPLACE TRIGGER country_before_update
-BEFORE UPDATE ON country FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON country FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -145,20 +147,20 @@ CREATE SEQUENCE city_sequence;
 
 
 CREATE OR REPLACE TRIGGER city_before_trigger
-BEFORE INSERT ON city FOR EACH ROW
+    BEFORE INSERT ON city FOR EACH ROW
 BEGIN
-  IF (:NEW.city_id IS NULL) THEN
-SELECT city_sequence.nextval INTO :NEW.city_id
-FROM DUAL;
-END IF;
- :NEW.last_update:=current_date;
+    IF (:NEW.city_id IS NULL) THEN
+        SELECT city_sequence.nextval INTO :NEW.city_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER city_before_update
-BEFORE UPDATE ON city FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON city FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -185,26 +187,26 @@ CREATE  INDEX idx_fk_city_id ON address(city_id);
 ALTER TABLE address ADD  CONSTRAINT fk_address_city FOREIGN KEY (city_id) REFERENCES city (city_id);
 
 
-  --DROP SEQUENCE city_sequence;
+--DROP SEQUENCE city_sequence;
 
 CREATE SEQUENCE address_sequence;
 
 
 CREATE OR REPLACE TRIGGER address_before_trigger
-BEFORE INSERT ON address FOR EACH ROW
+    BEFORE INSERT ON address FOR EACH ROW
 BEGIN
-  IF (:NEW.address_id IS NULL) THEN
-SELECT address_sequence.nextval INTO :NEW.address_id
-FROM DUAL;
-END IF;
- :NEW.last_update:=current_date;
+    IF (:NEW.address_id IS NULL) THEN
+        SELECT address_sequence.nextval INTO :NEW.address_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER address_before_update
-BEFORE UPDATE ON address FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON address FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -241,13 +243,13 @@ END;
 
 
 CREATE TABLE director (
-      director_id INT NOT NULL, --- this column will be filled with TSID long value
-      first_name VARCHAR(45) NOT NULL,
-      last_name VARCHAR(45) NOT NULL,
-      last_update DATE DEFAULT sysdate,
-      CONSTRAINT pk_director PRIMARY KEY (director_id)
+                          director_id INT NOT NULL, --- this column will be filled with TSID long value
+                          first_name VARCHAR(45) NOT NULL,
+    last_name VARCHAR(45) NOT NULL,
+    last_update DATE DEFAULT sysdate,
+    CONSTRAINT pk_director PRIMARY KEY (director_id)
 
-);
+    );
 
 
 --
@@ -255,16 +257,16 @@ CREATE TABLE director (
 --
 
 CREATE TABLE vanity_van (
-        van_id VARCHAR(45) NOT NULL, --- this column will be filled with TSID string value
-        name VARCHAR(45) NOT NULL,
-        last_update DATE DEFAULT sysdate,
-        CONSTRAINT pk_vanity_van PRIMARY KEY (van_id)
-);
+                            van_id VARCHAR(45) NOT NULL, --- this column will be filled with TSID string value
+                            name VARCHAR(45) NOT NULL,
+    last_update DATE DEFAULT sysdate,
+    CONSTRAINT pk_vanity_van PRIMARY KEY (van_id)
+    );
 
 CREATE OR REPLACE TRIGGER language_before_update
-BEFORE UPDATE ON language FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON language FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -285,20 +287,20 @@ CREATE SEQUENCE category_sequence;
 
 
 CREATE OR REPLACE TRIGGER category_before_trigger
-BEFORE INSERT ON category FOR EACH ROW
+    BEFORE INSERT ON category FOR EACH ROW
 BEGIN
-  IF (:NEW.category_id IS NULL) THEN
-SELECT category_sequence.nextval INTO :NEW.category_id
-FROM DUAL;
-END IF;
-  :NEW.last_update:=current_date;
+    IF (:NEW.category_id IS NULL) THEN
+        SELECT category_sequence.nextval INTO :NEW.category_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER category_before_update
-BEFORE UPDATE ON category FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON category FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -332,20 +334,20 @@ CREATE SEQUENCE customer_sequence;
 
 
 CREATE OR REPLACE TRIGGER customer_before_trigger
-BEFORE INSERT ON customer FOR EACH ROW
+    BEFORE INSERT ON customer FOR EACH ROW
 BEGIN
-  IF (:NEW.customer_id IS NULL) THEN
-SELECT customer_sequence.nextval INTO :NEW.customer_id
-FROM DUAL;
-END IF;
-  :NEW.last_update:=current_date;
-  :NEW.create_date:=current_date;
+    IF (:NEW.customer_id IS NULL) THEN
+        SELECT customer_sequence.nextval INTO :NEW.customer_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
+    :NEW.create_date:=current_date;
 END;
 
 CREATE OR REPLACE TRIGGER customer_before_update
-BEFORE UPDATE ON customer FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON customer FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 --
@@ -353,23 +355,23 @@ END;
 --
 
 CREATE TABLE film (
-      film_id INT NOT NULL,
-      title VARCHAR(255) NOT NULL,
-      description CLOB DEFAULT NULL,
-      release_year VARCHAR(4) DEFAULT NULL,
-      language_id INT NOT NULL,
-      original_language_id INT DEFAULT NULL,
-      rental_duration SMALLINT  DEFAULT 3 NOT NULL,
-      rental_rate DECIMAL(4,2) DEFAULT 4.99 NOT NULL,
-      length SMALLINT DEFAULT NULL,
-      replacement_cost DECIMAL(5,2) DEFAULT 19.99 NOT NULL,
-      rating VARCHAR(10) DEFAULT 'G',
-      special_features VARCHAR(100) DEFAULT NULL,
-      last_update DATE DEFAULT sysdate,
-      prequel_film_id INT DEFAULT NULL,
-      CONSTRAINT pk_film PRIMARY KEY  (film_id),
-      CONSTRAINT fk_film_language FOREIGN KEY (language_id) REFERENCES language (language_id) ,
-      CONSTRAINT fk_film_language_original FOREIGN KEY (original_language_id) REFERENCES language (language_id)
+                      film_id INT NOT NULL,
+                      title VARCHAR(255) NOT NULL,
+                      description CLOB DEFAULT NULL,
+                      release_year VARCHAR(4) DEFAULT NULL,
+                      language_id INT NOT NULL,
+                      original_language_id INT DEFAULT NULL,
+                      rental_duration SMALLINT  DEFAULT 3 NOT NULL,
+                      rental_rate DECIMAL(4,2) DEFAULT 4.99 NOT NULL,
+                      length SMALLINT DEFAULT NULL,
+                      replacement_cost DECIMAL(5,2) DEFAULT 19.99 NOT NULL,
+                      rating VARCHAR(10) DEFAULT 'G',
+                      special_features VARCHAR(100) DEFAULT NULL,
+                      last_update DATE DEFAULT sysdate,
+                      prequel_film_id INT DEFAULT NULL,
+                      CONSTRAINT pk_film PRIMARY KEY  (film_id),
+                      CONSTRAINT fk_film_language FOREIGN KEY (language_id) REFERENCES language (language_id) ,
+                      CONSTRAINT fk_film_language_original FOREIGN KEY (original_language_id) REFERENCES language (language_id)
 );
 
 ALTER TABLE film ADD CONSTRAINT CHECK_special_features CHECK(special_features is null or
@@ -395,13 +397,13 @@ CREATE SEQUENCE film_sequence INCREMENT BY 1 START WITH 6;
 --
 
 CREATE TABLE review (
-        review_id VARCHAR(20) NOT NULL, --- this column will be filled with TSID string value
-        message VARCHAR(100) NOT NULL,
-        rating INT NOT NULL,
-        film_id INT NOT NULL,
-        last_update DATE DEFAULT sysdate,
-        CONSTRAINT pk_review PRIMARY KEY  (review_id)
-);
+                        review_id VARCHAR(20) NOT NULL, --- this column will be filled with TSID string value
+                        message VARCHAR(100) NOT NULL,
+    rating INT NOT NULL,
+    film_id INT NOT NULL,
+    last_update DATE DEFAULT sysdate,
+    CONSTRAINT pk_review PRIMARY KEY  (review_id)
+    );
 
 /*
 CREATE OR REPLACE TRIGGER film_before_trigger
@@ -427,12 +429,12 @@ END;
 --
 
 CREATE TABLE film_actor (
-            actor_id INT NOT NULL,
-            film_id  INT NOT NULL,
-            last_update DATE DEFAULT sysdate,
-            CONSTRAINT pk_film_actor PRIMARY KEY  (actor_id,film_id),
-            CONSTRAINT fk_film_actor_actor FOREIGN KEY (actor_id) REFERENCES actor (actor_id),
-            CONSTRAINT fk_film_actor_film FOREIGN KEY (film_id) REFERENCES film (film_id)
+                            actor_id INT NOT NULL,
+                            film_id  INT NOT NULL,
+                            last_update DATE DEFAULT sysdate,
+                            CONSTRAINT pk_film_actor PRIMARY KEY  (actor_id,film_id),
+                            CONSTRAINT fk_film_actor_actor FOREIGN KEY (actor_id) REFERENCES actor (actor_id),
+                            CONSTRAINT fk_film_actor_film FOREIGN KEY (film_id) REFERENCES film (film_id)
 );
 
 CREATE  INDEX idx_fk_film_actor_film ON film_actor(film_id);
@@ -474,16 +476,16 @@ CREATE  INDEX idx_fk_film_category_category ON film_category(category_id);
 
 
 CREATE OR REPLACE TRIGGER film_category_before_trigger
-BEFORE INSERT ON film_category FOR EACH ROW
-BEGIN
+    BEFORE INSERT ON film_category FOR EACH ROW
+    BEGIN
     :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER film_category_before_update
-BEFORE UPDATE ON film_category FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON film_category FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 --
@@ -522,19 +524,19 @@ CREATE SEQUENCE inventory_sequence;
 
 
 CREATE OR REPLACE TRIGGER inventory_before_trigger
-BEFORE INSERT ON inventory FOR EACH ROW
+    BEFORE INSERT ON inventory FOR EACH ROW
 BEGIN
- IF (:NEW.inventory_id IS NULL) THEN
-SELECT inventory_sequence.nextval INTO :NEW.inventory_id
-FROM DUAL;
-END IF;
-  :NEW.last_update:=current_date;
+    IF (:NEW.inventory_id IS NULL) THEN
+        SELECT inventory_sequence.nextval INTO :NEW.inventory_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 CREATE OR REPLACE TRIGGER inventory_before_update
-BEFORE UPDATE ON inventory FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON inventory FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -570,20 +572,20 @@ CREATE SEQUENCE staff_sequence;
 
 
 CREATE OR REPLACE TRIGGER staff_before_trigger
-BEFORE INSERT ON staff FOR EACH ROW
+    BEFORE INSERT ON staff FOR EACH ROW
 BEGIN
- IF (:NEW.staff_id IS NULL) THEN
-SELECT staff_sequence.nextval INTO :NEW.staff_id
-FROM DUAL;
-END IF;
-  :NEW.last_update:=current_date;
+    IF (:NEW.staff_id IS NULL) THEN
+        SELECT staff_sequence.nextval INTO :NEW.staff_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER staff_before_update
-BEFORE UPDATE ON staff FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON staff FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -615,20 +617,20 @@ CREATE SEQUENCE store_sequence;
 
 
 CREATE OR REPLACE TRIGGER store_before_trigger
-BEFORE INSERT ON store FOR EACH ROW
+    BEFORE INSERT ON store FOR EACH ROW
 BEGIN
- IF (:NEW.store_id IS NULL) THEN
-SELECT store_sequence.nextval INTO :NEW.store_id
-FROM DUAL;
-END IF;
- :NEW.last_update:=current_date;
+    IF (:NEW.store_id IS NULL) THEN
+        SELECT store_sequence.nextval INTO :NEW.store_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER store_before_update
-BEFORE UPDATE ON store FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON store FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -660,20 +662,20 @@ CREATE SEQUENCE payment_sequence;
 
 
 CREATE OR REPLACE TRIGGER payment_before_trigger
-BEFORE INSERT ON payment FOR EACH ROW
+    BEFORE INSERT ON payment FOR EACH ROW
 BEGIN
- IF (:NEW.payment_id IS NULL) THEN
-SELECT payment_sequence.nextval INTO :NEW.payment_id
-FROM DUAL;
-END IF;
- :NEW.last_update:=current_date;
+    IF (:NEW.payment_id IS NULL) THEN
+        SELECT payment_sequence.nextval INTO :NEW.payment_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER payment_before_update
-BEFORE UPDATE ON payment FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON payment FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -706,20 +708,20 @@ CREATE SEQUENCE rental_sequence;
 
 
 CREATE OR REPLACE TRIGGER rental_before_trigger
-BEFORE INSERT ON rental FOR EACH ROW
+    BEFORE INSERT ON rental FOR EACH ROW
 BEGIN
- IF (:NEW.rental_id IS NULL) THEN
-SELECT rental_sequence.nextval INTO :NEW.rental_id
-FROM DUAL;
-END IF;
- :NEW.last_update:=current_date;
+    IF (:NEW.rental_id IS NULL) THEN
+        SELECT rental_sequence.nextval INTO :NEW.rental_id
+        FROM DUAL;
+    END IF;
+    :NEW.last_update:=current_date;
 END;
 
 
 CREATE OR REPLACE TRIGGER rental_before_update
-BEFORE UPDATE ON rental FOR EACH ROW
-BEGIN
-  :NEW.last_update:=current_date;
+    BEFORE UPDATE ON rental FOR EACH ROW
+    BEGIN
+    :NEW.last_update:=current_date;
 END;
 
 
@@ -731,5 +733,3 @@ ALTER TABLE inventory ADD CONSTRAINT fk_inventory_store FOREIGN KEY (store_id) R
 ALTER TABLE staff ADD CONSTRAINT fk_staff_store FOREIGN KEY (store_id) REFERENCES store (store_id);
 
 ALTER TABLE payment ADD CONSTRAINT fk_payment_rental FOREIGN KEY (rental_id) REFERENCES rental (rental_id) ON DELETE SET NULL;
-
-


### PR DESCRIPTION
Tested all crud endpoint using timestamps for all databases except Oracle.

1. One test fails on Postgresql timestamp insertion with incorrect DateTime.

Error Type
DateTime parse error.

Reason.
The processing of postgres data insertion is 'parsed by hand' unlike the others which delegate to the Database itself.
This causes a Date parse error for incorrect Datetime which is not handled in the parsing process. Therefore the server crashes and the error is not propagated and sent to the client.

Proposed Solution.
Make the insertion delegate to the db like all other db supports, so that errors will be caught and properly propagated.